### PR TITLE
Feature/overwrite existing (downscaled) files

### DIFF
--- a/TopoPyScale/topoclass.py
+++ b/TopoPyScale/topoclass.py
@@ -458,7 +458,7 @@ class Topoclass(object):
                 [file for file in Path(self.config.project.directory).glob('**/*') if re.match(f_pattern, file.name)])
             for file in existing_files:
                 file.unlink()
-                print(file.name, 'removed.')
+                print(f'existing file {file.name} removed.')
 
             for pt_id in self.toposub.df_centroids.point_id.values:
                 print(f'Concatenating point {pt_id}')

--- a/TopoPyScale/topoclass.py
+++ b/TopoPyScale/topoclass.py
@@ -16,7 +16,6 @@ import os
 import re
 import shutil
 import sys
-from ctypes import Union
 from pathlib import Path
 
 import matplotlib.pyplot as plt
@@ -427,7 +426,8 @@ class Topoclass(object):
         f_pattern = self.config.outputs.file.downscaled_pt
 
         if '*' not in f_pattern:
-            raise ValueError(f'The filepattern for the downscaled files does need to have a * in the name. You provided {f_pattern}')
+            raise ValueError(
+                f'The filepattern for the downscaled files does need to have a * in the name. You provided {f_pattern}')
 
         if self.config.project.split.IO:
             for i, start in enumerate(self.time_splitter.start_list):


### PR DESCRIPTION
With this implementation, all downscaled files with the given filepattern (of the config file) get deleted prior to concatenating the downscaled products. So the parameter 'clean_outputs' can be set to false, but the files with the filepattern get overwritten.
-> this has the advantage when e.g. once downscale spatial and once the points.

If wanted, an additional boolean config parameterr  'overwrite_output' could make sure, this is wanted.

The relevant changes are all between the lines 424 and 477. The res is just auto formation.