### PR TITLE
to_musa() bug when attempting downscaling on a list of points

### DIFF
--- a/TopoPyScale/topo_export.py
+++ b/TopoPyScale/topo_export.py
@@ -85,6 +85,8 @@ def to_musa(ds,
     Returns:
         Save downscaled timeseries and toposub cluster mapping
     """
+    if da_label is not None:
+    	da_label.to_netcdf(path + fname_labels)
 
     da_label.to_netcdf(path + fname_labels)
 

--- a/TopoPyScale/topoclass.py
+++ b/TopoPyScale/topoclass.py
@@ -652,10 +652,14 @@ class Topoclass(object):
         Args:
             fname: filename of the netcdf 
         """
+        try:
+            labels = self.toposub.ds_param.cluster_labels
+        except Exception:
+            labels = None
 
         te.to_musa(ds=self.downscaled_pts,
                    df_pts=self.toposub.df_centroids,
-                   da_label=self.toposub.ds_param.cluster_labels,
+                   da_label=labels,
                    fname_met=fname_met,
                    fname_labels=fname_labels,
                    path=self.config.project.directory + 'outputs/',


### PR DESCRIPTION
When `method: points`, `to_musa()` tries to write the labels, but they are not available, generating an exception.

This is a very simple non-invasive fix, tested for both `method:points` and `method: toposub`