### PR TITLE
Correct sign in solar_geom azimuth

### DIFF
--- a/TopoPyScale/solar_geom.py
+++ b/TopoPyScale/solar_geom.py
@@ -79,7 +79,7 @@ def get_solar_geom(df_position,
     ds = xr.Dataset(
         {
             "zenith": (["point_name", "time"], np.deg2rad(arr_val[:, 0, :])),
-            "azimuth": (["point_name", "time"], np.deg2rad(arr_val[:,1,:] - 180)),
+            "azimuth": (["point_name", "time"], np.deg2rad(180 - arr_val[:,1,:])),
             "elevation": (["point_name", "time"], np.deg2rad(arr_val[:, 2, :])),
         },
         coords={


### PR DESCRIPTION
there are two different conventions with regards to solar azimuths in pvlib (0N, 90E, 180S, 270W) while here in TopoPyScale we have (0S,180N, -90W and 90E), so we need to change sign other than subtracting 180.

I realized the error because I had strong SW radiation in the morning and not in the afternoon: