### PR TITLE
Prevent numerical instability in pt_downscale_radiations

### DIFF
--- a/TopoPyScale/topo_scale.py
+++ b/TopoPyScale/topo_scale.py
@@ -265,9 +265,13 @@ def pt_downscale_radiations(row, ds_solar, horizon_da, meta, output_dir):
         down_pt['LW'] = row.svf * surf_interp['aef'] * sbc * down_pt.t ** 4
 
     kt = surf_interp.ssrd * 0
-    sunset = ds_solar.sunset.astype(bool).compute()
-    mu0 = ds_solar.mu0
+    sunset = ds_solar.sunset.astype(bool).compute()    
     SWtoa = ds_solar.SWtoa
+    mu0 = ds_solar.mu0
+    # prevent numerical instability with the mu0 (in denominator of formulas at lines 304 and 307) when sun is very close to horizon (cos(75) ~= 0.25)
+    mu0_stable = mu0.where(mu0 > 0.25, 0.25)
+
+
 
     # pdb.set_trace()
     kt[~sunset] = (surf_interp.ssrd[~sunset] / tstep_seconds) / SWtoa[~sunset]  # clearness index
@@ -281,12 +285,17 @@ def pt_downscale_radiations(row, ds_solar, horizon_da, meta, output_dir):
     down_pt['SW_diffuse'] = row.svf * surf_interp.SW_diffuse
 
     surf_interp['SW_direct'] = surf_interp.SW - surf_interp.SW_diffuse
+    # prevent the case in which SWtoa < SW_direct, which would cause negative ka at line 292.
+    surf_interp['SW_direct'][surf_interp['SW_direct'] > SWtoa] = SWtoa[surf_interp['SW_direct'] > SWtoa] 
+
+
+    
     # scale direct solar radiation using Beer's law (see Aalstad 2019, Appendix A)
     ka = surf_interp.ssrd * 0
     # pdb.set_trace()
     ka[~sunset] = (g * mu0[~sunset] / down_pt.p) * np.log(SWtoa[~sunset] / surf_interp.SW_direct[~sunset])
     # Illumination angle
-    down_pt['cos_illumination_tmp'] = mu0 * np.cos(row.slope) + np.sin(ds_solar.zenith) * \
+    down_pt['cos_illumination_tmp'] = mu0_stable * np.cos(row.slope) + np.sin(ds_solar.zenith) * \
                                       np.sin(row.slope) * np.cos(ds_solar.azimuth - row.aspect)
     down_pt['cos_illumination'] = down_pt.cos_illumination_tmp * (
             down_pt.cos_illumination_tmp > 0)  # remove selfdowing ccuring when |Solar.azi - aspect| > 90
@@ -300,10 +309,10 @@ def pt_downscale_radiations(row, ds_solar, horizon_da, meta, output_dir):
     shade = (horizon > ds_solar.elevation)
     down_pt['SW_direct_tmp'] = down_pt.t * 0
     down_pt['SW_direct_tmp'][~sunset] = SWtoa[~sunset] * np.exp(
-        -ka[~sunset] * down_pt.p[~sunset] / (g * mu0[~sunset]))
+        -ka[~sunset] * down_pt.p[~sunset] / (g * mu0_stable[~sunset])) # avoid exploding denominator by using mu0_stable
     down_pt['SW_direct'] = down_pt.t * 0
     down_pt['SW_direct'][~sunset] = down_pt.SW_direct_tmp[~sunset] * (
-            down_pt.cos_illumination[~sunset] / mu0[~sunset]) * (1 - shade)
+            down_pt.cos_illumination[~sunset] / mu0_stable[~sunset]) * (1 - shade) # avoid exploding denominator by using mu0_stable
     down_pt['SW'] = down_pt.SW_diffuse + down_pt.SW_direct
 
     # currently drop azimuth and level as they are coords. Could be passed to variables instead.


### PR DESCRIPTION
Hi everyone,

I have experience some numerical instability when downscaling the Shortwave Radiation. I am downscaling ERA5 to a set of representative points in a basin. Some of them have large slope and I think that's why I encountered this problem.
I noticed the problem as in some points I got nonphysical values of SW, caused by a large SW_direct component. Here's an example of a west-facing and 30 degrees steep point: 

<img width="955" height="380" alt="image" src="https://github.com/user-attachments/assets/3aa9cbbb-ab96-4e82-b0cf-de46832883e2" />

I get a spike of SW radiation in the evening (sorry for the wrong time axis, times are in UTC but the basin is at UTC-7). That is caused by the fact that the ratio between cos_illumination and mu0 explodes, likely because there is a very small value of mu0 just before the sunset.

I thought of solving it by setting a minimum value of mu0 as 0.25 ` mu0_stable = mu0.where(mu0 > 0.25, 0.25)`. That value corresponds to a sun zenith of 75 degrees. I called this mu0_stable and substituted it in the formulas where mu0 appears in the denominator.

Moreover, while I was exploring these terms I also discovered that, for some approximation errors I guess, the calculation of surf_interp['SW_direct'] leads in some cases to values slightly larger than the SW radiation on the top of the atmosphere (SWtoa). When that happens, I got that ka was at times negative, as you can see in the next figure (representing another west-facing point but steeper). Negative ka also leads to exploding SW_direct, this time in the formula for down_pt['SW_direct_tmp'].


<img width="1408" height="375" alt="sw_direct swtoa" src="https://github.com/user-attachments/assets/b7544f1f-d06f-46df-a627-4c468b420ff5" />

So I removed the values of surf_interp['SW_direct']  that are larger than SWtoa by substituting them with SWtoa:

`    surf_interp['SW_direct'][surf_interp['SW_direct'] > SWtoa] = SWtoa[surf_interp['SW_direct'] > SWtoa] 
`

I've already discussed about the first issue with @krisaalstad. However, I'm not sure at all that these fixes work well in other cases. I guess there needs to be some testing in other basins before accepting these?
If needed I can provide you with the dataset I'm working with.

Cheers,
Marco.

